### PR TITLE
Added language option for company report getting

### DIFF
--- a/src/Service/CompanyService.php
+++ b/src/Service/CompanyService.php
@@ -36,12 +36,13 @@ class CompanyService
 
     /**
      * This function is used to call the endpoint that gets the company report
-     * @param  string $id The ID of the given company that you want to get a report for
-     * @return array   Returns the results of the  get endpoint
+     * @param string $id The ID of the given company that you want to get a report for
+     * @param string $reportLang
+     * @return Company Returns the results of the  get endpoint
      */
-    public function get(string $id) : Company
+    public function get(string $id, $reportLang = 'en') : Company
     {
-        return new Company($this->client, $this->client->get('companies/'.$id));
+        return new Company($this->client, $this->client->get('companies/'.$id, ['language' => $reportLang]));
     }
 
     /**

--- a/src/Service/CompanyService.php
+++ b/src/Service/CompanyService.php
@@ -40,7 +40,7 @@ class CompanyService
      * @param string $reportLang
      * @return Company Returns the results of the  get endpoint
      */
-    public function get(string $id, $reportLang = 'en') : Company
+    public function get(string $id, string $reportLang = 'en') : Company
     {
         return new Company($this->client, $this->client->get('companies/'.$id, ['language' => $reportLang]));
     }


### PR DESCRIPTION
Added a possibility to set a language report query param
in the postman API documentary exist such feature. Would be nice to have such one in the library according to get ability change report language. 
A variant with `$company = $client->companies()->get($id . '?language=no');` didn't work acording to way of passing arguments to the Guzzle librarry 