### PR TITLE
Reason code mandatory due to German law

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ $creditsafe->countries()->access();
 
 $creditsafe->companies()->searchCriteria(['countries' => 'GB']);
 
-
 ```
+
 ### Company search pagination
 ```php
 $search = $creditsafe->companies()->search(['countries' => 'GB', 'name' => 'GOOGLE UK LIMITED']);
@@ -39,9 +39,24 @@ foreach ($search as $result) {
 }
 ```
 
+### Get Custom report data options
+```php
+$creditsafe->()->reportCustomData()->get('DE');
+```
+
 ### Get company report
 ```php
 $creditsafe->companies()->get('GB001-0-03977902');
+```
+
+### Change report language
+```php
+$creditsafe->companies()->get('GB001-0-03977902', 'FR');
+```
+
+### Adding reason code as extra parameter needed for German reports
+```php
+$creditsafe->companies()->get('GB001-0-03977902', 'DE', ['customData' => 'de_reason_code::1']);
 ```
 
 ## Running tests

--- a/src/Client.php
+++ b/src/Client.php
@@ -11,7 +11,6 @@ use GuzzleHttp\Psr7;
  */
 class Client
 {
-
     protected $http_client;
 
     /**
@@ -40,6 +39,11 @@ class Client
     protected $monitor;
 
     /**
+     * @var Service\ReportCustomData
+     */
+    protected $reportCustomData;
+
+    /**
      * construct function that builds the client class
      * @param array $config creditsafe configuration
      */
@@ -62,12 +66,12 @@ class Client
      * @return void
      * @throws Exception\Unauthorized if the provided authentication details are not valid
      */
-    public function authenticate() : void
+    public function authenticate(): void
     {
         try {
             $authenticate = $this->http_client->request('POST', 'authenticate', [
-                'json'=> [
-                    'username'=> $this->config['username'],
+                'json' => [
+                    'username' => $this->config['username'],
                     'password' => $this->config['password']
                 ]
             ]);
@@ -91,10 +95,10 @@ class Client
     /**
      * set token
      * @param string $token Token must be set to have access
-     *  to the api and is only valid for an hour
+     * to the api and is only valid for a hour
      * @return void
      */
-    public function setToken(string $token) : void
+    public function setToken(string $token): void
     {
         $this->token = (new Parser())->parse($token);
     }
@@ -102,7 +106,7 @@ class Client
     /**
      * @return Token
      */
-    public function getToken() : Token
+    public function getToken(): Token
     {
         return $this->token;
     }
@@ -111,7 +115,7 @@ class Client
      * Checks if token is valid
      * @return void
      */
-    public function checkToken() : void
+    public function checkToken(): void
     {
         /**
          * argument required as of lcobucci/jwt 3.4+
@@ -130,7 +134,7 @@ class Client
      * @param  array  $params   Sets params for a endpoint
      * @return array    Returns the results of the endpoint
      */
-    public function request(string $type, string $endpoint, array $params = []) : array
+    public function request(string $type, string $endpoint, array $params = []): array
     {
 
         $this->checkToken();
@@ -187,12 +191,12 @@ class Client
     }
 
     /**
-     *  A function that handles the creation of a GET  Request
+     *  A function that handles the creation of a GET Request
      * @param  string $endpoint  An endpoint used to create an request
-     * @param  array  $params   Sets params for a endpoint
+     * @param  array  $params   Sets params for an endpoint
      * @return array  Returns the results of the endpoint
      */
-    public function get(string $endpoint, array $params = []) : array
+    public function get(string $endpoint, array $params = []): array
     {
         return $this->request('GET', $endpoint, $params);
     }
@@ -201,7 +205,7 @@ class Client
      * Get Company Events
      * @return Service\CompanyEventService Returns Company Events
      */
-    public function monitoring() : Service\CompanyEventService
+    public function monitoring(): Service\CompanyEventService
     {
         if (!isset($this->monitor)) {
             $this->monitor = new Service\CompanyEventService($this);
@@ -210,10 +214,10 @@ class Client
     }
 
     /**
-     *  Get company services
+     * Get company services
      * @return Service\CompanyService Returns Company Services
      */
-    public function companies() : Service\CompanyService
+    public function companies(): Service\CompanyService
     {
         if (!isset($this->company)) {
             $this->company = new Service\CompanyService($this);
@@ -222,10 +226,10 @@ class Client
     }
 
     /**
-     *  Get Countries
+     * Get Countries
      * @return Service\CountryService  Returns the Countries
      */
-    public function countries() : Service\CountryService
+    public function countries(): Service\CountryService
     {
         if (!isset($this->countries)) {
             $this->countries = new Service\CountryService($this);
@@ -234,9 +238,21 @@ class Client
     }
 
     /**
+     * Get reportCustomData service
+     * @return Service\ReportCustomDataService
+     */
+    public function reportCustomData(): Service\ReportCustomDataService
+    {
+        if (is_null($this->reportCustomData)) {
+            $this->reportCustomData = new Service\ReportCustomDataService($this);
+        }
+        return $this->reportCustomData;
+    }
+
+    /**
      * @return array
      */
-    public function getDefaultConfig() : array
+    public function getDefaultConfig(): array
     {
         return [
             'apiURI' => 'https://connect.creditsafe.com/',
@@ -247,7 +263,7 @@ class Client
      *  Function gets the base url for the api by concatenating the API URL and the API version
      * @return string Returns a string containing the base url
      */
-    public function getBaseURL() : string
+    public function getBaseURL(): string
     {
         return $this->getApiURL().$this->getApiVersion().'/';
     }
@@ -256,7 +272,7 @@ class Client
      * Function gets the Api url
      * @return string Returns a string containing the api url
      */
-    protected function getApiURL() : string
+    protected function getApiURL(): string
     {
         return $this->config['apiURI'];
     }
@@ -265,7 +281,7 @@ class Client
      * Function gets the Api Version
      * @return string Returns a string containing the Api Version
      */
-    protected function getApiVersion() : string
+    protected function getApiVersion(): string
     {
         return 'v1';
     }

--- a/src/Service/CompanyService.php
+++ b/src/Service/CompanyService.php
@@ -2,9 +2,9 @@
 
 namespace SynergiTech\Creditsafe\Service;
 
-use \SynergiTech\Creditsafe\ListResult;
-use \SynergiTech\Creditsafe\Models\CompanySearchResult;
-use \SynergiTech\Creditsafe\Models\Company;
+use SynergiTech\Creditsafe\ListResult;
+use SynergiTech\Creditsafe\Models\CompanySearchResult;
+use SynergiTech\Creditsafe\Models\Company;
 
 /**
  * This class is used by the client to call endpoints relating to a company
@@ -28,7 +28,7 @@ class CompanyService
      * @param  array  $params Contains params that can be passed to the endpoint
      * @return array   Returns the results of the search endpoint
      */
-    public function search(array $params) : ListResult
+    public function search(array $params): ListResult
     {
         $list = new ListResult($this->client, CompanySearchResult::class, 'companies', $params);
         return $list;
@@ -38,11 +38,13 @@ class CompanyService
      * This function is used to call the endpoint that gets the company report
      * @param string $id The ID of the given company that you want to get a report for
      * @param string $reportLang
-     * @return Company Returns the results of the  get endpoint
+     * @param array $params
+     * @return Company Returns the results of the get endpoint
      */
-    public function get(string $id, string $reportLang = 'en') : Company
+    public function get(string $id, string $reportLang = 'en', array $params = []): Company
     {
-        return new Company($this->client, $this->client->get('companies/'.$id, ['language' => $reportLang]));
+        $params = array_merge($params, ['language' => $reportLang]);
+        return new Company($this->client, $this->client->get('companies/'.$id, $params));
     }
 
     /**
@@ -51,7 +53,7 @@ class CompanyService
      * @param  array $params Contains params that can be passed to the endpoint
      * @return array    Returns the results of the  searchCriteria endpoint
      */
-    public function searchCriteria(array $params) :array
+    public function searchCriteria(array $params): array
     {
         return $this->client->get('companies/searchcriteria', $params);
     }

--- a/src/Service/ReportCustomDataService.php
+++ b/src/Service/ReportCustomDataService.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SynergiTech\Creditsafe\Service;
+
+class ReportCustomDataService
+{
+    protected $client;
+
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param string $countryCode An ISO/Alpha-2 country code to display any special mandatory parameters
+     * when ordering a Credit Report in that territory.
+     * @return mixed
+     */
+    public function get(string $countryCode)
+    {
+        return $this->client->get('reportcustomdata/' . $countryCode);
+    }
+}


### PR DESCRIPTION
When requesting a creditreport of a German company, it's required by German law to provide a reason code.
All the possible values are retrievable via /reportcustomdata/countryCode
The company get method now accepts additional parameters array.

Used this pull request as a base:
https://github.com/SynergiTech/creditsafe-connect/pull/8

